### PR TITLE
feat: add flexible country name matching with multiple variants

### DIFF
--- a/internal/games/facts/game.go
+++ b/internal/games/facts/game.go
@@ -167,7 +167,7 @@ func (g *Game) makeGuess() {
 		return
 	}
 
-	if utils.MatchesCountry(guess, *g.currentCountry) {
+	if utils.MatchCountry(guess, *g.currentCountry, utils.MatchAll) {
 		currentFactText := g.factLabel.Text
 		g.guessHistory = append(g.guessHistory, GuessHistory{
 			Guess: fmt.Sprintf("%s ✅", guess),

--- a/internal/games/guessing/game.go
+++ b/internal/games/guessing/game.go
@@ -10,6 +10,7 @@ import (
 	"flagged-it/internal/data"
 	"flagged-it/internal/data/models"
 	"flagged-it/internal/ui/components"
+	"flagged-it/internal/utils"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
@@ -221,7 +222,7 @@ func (g *Game) newGame() {
 
 func (g *Game) getCountry(countries []models.Country, name string) *models.Country {
 	for _, country := range countries {
-		if strings.EqualFold(country.Name.Common, name) {
+		if utils.MatchCountry(name, country, utils.MatchAll) {
 			return &country
 		}
 	}
@@ -243,7 +244,7 @@ func (g *Game) makeGuess() {
 	g.guesses = append(g.guesses, *guessedCountry)
 	g.addGuessRow(guessedCountry)
 
-	if strings.EqualFold(guess, g.currentCountry.Name.Common) {
+	if utils.MatchCountry(guess, *g.currentCountry, utils.MatchAll) {
 		g.statusLabel.SetText(fmt.Sprintf("Correct! It was %s!", g.currentCountry.Name.Common))
 		g.guessEntry.Disable()
 		g.guessBtn.Disable()

--- a/internal/games/list/game.go
+++ b/internal/games/list/game.go
@@ -185,7 +185,7 @@ func (g *Game) makeGuess() {
 	var matchedCountry models.Country
 
 	for _, country := range g.allCountries {
-		if utils.MatchesCountry(guess, country) && !g.guessedCountries[strings.ToLower(country.Name.Common)] {
+		if utils.MatchCountry(guess, country, utils.MatchCommon|utils.MatchOfficial) && !g.guessedCountries[strings.ToLower(country.Name.Common)] {
 			g.guessedCountries[strings.ToLower(country.Name.Common)] = true
 			matchedCountry = country
 			found = true

--- a/internal/games/shape/game.go
+++ b/internal/games/shape/game.go
@@ -429,7 +429,7 @@ func (g *Game) checkGuess(guess string) {
 
 	g.total++
 
-	if utils.MatchesCountryByName(guess, g.currentCountry.Properties.Name) {
+	if utils.MatchCountry(guess, models.Country{Name: models.CountryName{Common: g.currentCountry.Properties.Name}}, utils.MatchAll) {
 		g.score++
 		g.resultLabel.SetText("Correct! It's " + g.currentCountry.Properties.Name)
 	} else {

--- a/internal/utils/matcher.go
+++ b/internal/utils/matcher.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"strings"
+
+	"flagged-it/internal/data/models"
+)
+
+type MatchLevel int
+
+const (
+	MatchCommon MatchLevel = 1 << iota
+	MatchOfficial
+	MatchAbbreviation
+	MatchAll = MatchCommon | MatchOfficial | MatchAbbreviation
+)
+
+func MatchCountry(input string, country models.Country, level MatchLevel) bool {
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	if (level & MatchCommon) != 0 {
+		if strings.EqualFold(input, country.Name.Common) {
+			return true
+		}
+	}
+
+	if (level & MatchOfficial) != 0 {
+		if strings.EqualFold(input, country.Name.Official) {
+			return true
+		}
+	}
+
+	if (level & MatchAbbreviation) != 0 {
+		if strings.EqualFold(input, country.CCA2) || strings.EqualFold(input, country.CCA3) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
- create matcher utility with bitwise flag-based match levels
- support common names, official names, and country codes (CCA2/CCA3)
- update all input-based games to use flexible matching
- guessing, facts, shape games accept all variants
- list game accepts common and official names