### PR TITLE
feat: cover more translations

### DIFF
--- a/internal/games/facts/game.go
+++ b/internal/games/facts/game.go
@@ -63,7 +63,7 @@ func (g *Game) loadCountries() {
 }
 
 func (g *Game) setupUI() {
-	topBar := components.NewTopBar("Guess by Facts", g.backFunc, g.Reset)
+	topBar := components.NewTopBar(lang.X("game.facts.title", "Guess by Facts"), g.backFunc, g.Reset)
 
 	g.factLabel = widget.NewLabel("")
 	g.factLabel.Wrapping = fyne.TextWrapWord

--- a/internal/games/guessing/game.go
+++ b/internal/games/guessing/game.go
@@ -195,10 +195,11 @@ func (g *Game) addGuessRow(country *models.Country) {
 	flagTile := g.createFlagTile(country)
 	countryTile := g.createTile(country.Name.Common, nil, color.RGBA{100, 100, 100, 255})
 
+	translatedRegion := utils.TranslateRegion(country.Region)
 	row := container.NewGridWithColumns(5,
 		flagTile,
 		countryTile,
-		g.createTile(country.Region, nil, continentColor),
+		g.createTile(translatedRegion, nil, continentColor),
 		g.createTile(fmt.Sprintf("%d", country.Population), popIcon, popColor),
 		g.createTile(fmt.Sprintf("%.0f", country.Area), areaIcon, areaColor),
 	)

--- a/internal/games/list/game.go
+++ b/internal/games/list/game.go
@@ -121,9 +121,9 @@ func (g *Game) setupGameView() {
 			label := obj.(*widget.Label)
 			country := g.allCountries[id]
 			if g.guessedCountries[strings.ToLower(country.Name.Common)] {
-				label.SetText(fmt.Sprintf("%d. %s", id+1, country.Name.Common))
+				label.SetText(fmt.Sprintf(lang.X("game.list.country_item", "%d. %s"), id+1, country.Name.Common))
 			} else {
-				label.SetText(fmt.Sprintf("%d. ?", id+1))
+				label.SetText(fmt.Sprintf(lang.X("game.list.country_unknown", "%d. ?"), id+1))
 			}
 		},
 	)

--- a/internal/games/shape/game.go
+++ b/internal/games/shape/game.go
@@ -64,7 +64,7 @@ func NewGame(backFunc func(), scoreManager *utils.ScoreManager) *Game {
 }
 
 func (g *Game) setupUI() {
-	topBar := components.NewTopBar("Country Shape Game", g.backFunc, g.Reset)
+	topBar := components.NewTopBar(lang.X("game.shape.title", "Guess by Shape"), g.backFunc, g.Reset)
 
 	g.setupSelectionView()
 	g.setupGameView()

--- a/internal/translations/translations/cs.json
+++ b/internal/translations/translations/cs.json
@@ -83,5 +83,11 @@
   "region.europe": "Evropa",
   "region.americas": "Amerika",
   "region.oceania": "Oceánie",
-  "region.antarctica": "Antarktida"
+  "region.antarctica": "Antarktida",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Posouváme tektonické desky a formujeme státy...",
+  "html.loading_app": "Načítání aplikace...",
+  "html.error_title": "⚠️ Chyba při Načítání Aplikace",
+  "html.error_message": "Nepodařilo se načíst aplikaci. Obnovte prosím stránku a zkuste to znovu."
 }

--- a/internal/translations/translations/da.json
+++ b/internal/translations/translations/da.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oceanien",
-  "region.antarctica": "Antarktis"
+  "region.antarctica": "Antarktis",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Forskubber tektoniske plader for at danne lande...",
+  "html.loading_app": "Indlæser applikation...",
+  "html.error_title": "⚠️ Fejl ved Indlæsning af Applikation",
+  "html.error_message": "Kunne ikke indlæse applikationen. Opdater venligst siden og prøv igen."
 }

--- a/internal/translations/translations/de.json
+++ b/internal/translations/translations/de.json
@@ -77,12 +77,17 @@
   "game.higher_lower.start": "Spiel Starten",
   "game.higher_lower.population": "Bevölkerung: %d",
   "game.higher_lower.population_unknown": "Bevölkerung: ?",
-  "game.facts.guess_number": "Versuch %d: %s",
   "region.world": "Welt",
   "region.africa": "Afrika",
   "region.asia": "Asien",
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Ozeanien",
-  "region.antarctica": "Antarktis"
+  "region.antarctica": "Antarktis",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Verschieben tektonischer Platten zur Bildung von Ländern...",
+  "html.loading_app": "Anwendung wird geladen...",
+  "html.error_title": "⚠️ Fehler beim Laden der Anwendung",
+  "html.error_message": "Die Anwendung konnte nicht geladen werden. Bitte aktualisieren Sie die Seite und versuchen Sie es erneut."
 }

--- a/internal/translations/translations/en.json
+++ b/internal/translations/translations/en.json
@@ -19,6 +19,8 @@
   "game.list.choose_region": "Choose a region and try to name all countries in it!",
   "game.list.enter_country": "Enter country name...",
   "game.list.guess": "Guess",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
   "game.list.start_guessing": "Start guessing countries!",
   "game.list.completion": "Completion: %.0f%%",
   "game.list.correct_added": "Correct! %s added to the list.",

--- a/internal/translations/translations/es.json
+++ b/internal/translations/translations/es.json
@@ -12,7 +12,7 @@
   "game.flag.question": "¿A qué país pertenece esta bandera?",
   "game.correct": "¡Correcto! Es {{.Country}}!",
   "game.wrong": "¡Incorrecto! Era {{.Country}}",
-  "game.score": "Skóre: {{.Score}}/10",
+  "game.score": "Puntuación: {{.Score}}/10",
   "game.complete": "¡Juego Completo! Puntuación Final: {{.Score}}/10 ({{.Percent}}%)",
   "error.loading_countries": "Error al cargar datos de países",
   "game.list.select_region": "Seleccionar Región",
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Américas",
   "region.oceania": "Oceanía",
-  "region.antarctica": "Antártida"
+  "region.antarctica": "Antártida",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Desplazando placas tectónicas para formar países...",
+  "html.loading_app": "Cargando aplicación...",
+  "html.error_title": "⚠️ Error al Cargar la Aplicación",
+  "html.error_message": "No se pudo cargar la aplicación. Por favor, actualiza la página e inténtalo de nuevo."
 }

--- a/internal/translations/translations/fi.json
+++ b/internal/translations/translations/fi.json
@@ -83,5 +83,11 @@
   "region.europe": "Eurooppa",
   "region.americas": "Amerikka",
   "region.oceania": "Oseania",
-  "region.antarctica": "Antarktis"
+  "region.antarctica": "Antarktis",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Siirretään tektonisia laattoja muodostaakseen maita...",
+  "html.loading_app": "Ladataan sovellusta...",
+  "html.error_title": "⚠️ Virhe Sovelluksen Latauksessa",
+  "html.error_message": "Sovellusta ei voitu ladata. Päivitä sivu ja yritä uudelleen."
 }

--- a/internal/translations/translations/fil.json
+++ b/internal/translations/translations/fil.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antartika"
+  "region.antarctica": "Antartika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Inililipat ang mga tectonic plate upang mabuo ang mga bansa...",
+  "html.loading_app": "Naglo-load ng aplikasyon...",
+  "html.error_title": "⚠️ Error sa Pag-load ng Aplikasyon",
+  "html.error_message": "Nabigo ang pag-load ng aplikasyon. Pakirefresh ang pahina at subukan muli."
 }

--- a/internal/translations/translations/fr.json
+++ b/internal/translations/translations/fr.json
@@ -12,7 +12,7 @@
   "game.flag.question": "À quel pays appartient ce drapeau?",
   "game.correct": "Correct! C'est {{.Country}}!",
   "game.wrong": "Faux! C'était {{.Country}}",
-  "game.score": "Skóre: {{.Score}}/10",
+  "game.score": "Score: {{.Score}}/10",
   "game.complete": "Jeu Terminé! Score Final: {{.Score}}/10 ({{.Percent}}%)",
   "error.loading_countries": "Erreur de chargement des données des pays",
   "game.list.select_region": "Sélectionner une Région",
@@ -83,5 +83,11 @@
   "region.europe": "Europe",
   "region.americas": "Amériques",
   "region.oceania": "Océanie",
-  "region.antarctica": "Antarctique"
+  "region.antarctica": "Antarctique",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Déplacement des plaques tectoniques pour former des pays...",
+  "html.loading_app": "Chargement de l'application...",
+  "html.error_title": "⚠️ Erreur de Chargement de l'Application",
+  "html.error_message": "Échec du chargement de l'application. Veuillez actualiser la page et réessayer."
 }

--- a/internal/translations/translations/hr.json
+++ b/internal/translations/translations/hr.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oceanija",
-  "region.antarctica": "Antarktika"
+  "region.antarctica": "Antarktika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Pomicanje tektonskih ploča za formiranje zemalja...",
+  "html.loading_app": "Učitavanje aplikacije...",
+  "html.error_title": "⚠️ Greška pri Učitavanju Aplikacije",
+  "html.error_message": "Neuspjelo učitavanje aplikacije. Osvježite stranicu i pokušajte ponovno."
 }

--- a/internal/translations/translations/hu.json
+++ b/internal/translations/translations/hu.json
@@ -83,5 +83,11 @@
   "region.europe": "Európa",
   "region.americas": "Amerika",
   "region.oceania": "Óceánia",
-  "region.antarctica": "Antarktisz"
+  "region.antarctica": "Antarktisz",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Tektonikus lemezek eltolása országok kialakításához...",
+  "html.loading_app": "Alkalmazás betöltése...",
+  "html.error_title": "⚠️ Hiba az Alkalmazás Betöltésekor",
+  "html.error_message": "Az alkalmazás betöltése sikertelen. Kérjük, frissítse az oldalt és próbálja újra."
 }

--- a/internal/translations/translations/id.json
+++ b/internal/translations/translations/id.json
@@ -83,5 +83,11 @@
   "region.europe": "Eropa",
   "region.americas": "Amerika",
   "region.oceania": "Oseania",
-  "region.antarctica": "Antartika"
+  "region.antarctica": "Antartika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Menggeser lempeng tektonik untuk membentuk negara...",
+  "html.loading_app": "Memuat aplikasi...",
+  "html.error_title": "⚠️ Kesalahan Memuat Aplikasi",
+  "html.error_message": "Gagal memuat aplikasi. Silakan muat ulang halaman dan coba lagi."
 }

--- a/internal/translations/translations/it.json
+++ b/internal/translations/translations/it.json
@@ -12,7 +12,7 @@
   "game.flag.question": "A quale paese appartiene questa bandiera?",
   "game.correct": "Corretto! È {{.Country}}!",
   "game.wrong": "Sbagliato! Era {{.Country}}",
-  "game.score": "Skóre: {{.Score}}/10",
+  "game.score": "Punteggio: {{.Score}}/10",
   "game.complete": "Gioco Completato! Punteggio Finale: {{.Score}}/10 ({{.Percent}}%)",
   "error.loading_countries": "Errore nel caricamento dei dati dei paesi",
   "game.list.select_region": "Seleziona Regione",
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Americhe",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antartide"
+  "region.antarctica": "Antartide",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Spostando le placche tettoniche per formare i paesi...",
+  "html.loading_app": "Caricamento applicazione...",
+  "html.error_title": "⚠️ Errore nel Caricamento dell'Applicazione",
+  "html.error_message": "Impossibile caricare l'applicazione. Aggiorna la pagina e riprova."
 }

--- a/internal/translations/translations/ms.json
+++ b/internal/translations/translations/ms.json
@@ -83,5 +83,11 @@
   "region.europe": "Eropah",
   "region.americas": "Amerika",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antartika"
+  "region.antarctica": "Antartika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Mengalihkan plat tektonik untuk membentuk negara...",
+  "html.loading_app": "Memuatkan aplikasi...",
+  "html.error_title": "⚠️ Ralat Memuatkan Aplikasi",
+  "html.error_message": "Gagal memuatkan aplikasi. Sila muat semula halaman dan cuba lagi."
 }

--- a/internal/translations/translations/nb.json
+++ b/internal/translations/translations/nb.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oseania",
-  "region.antarctica": "Antarktis"
+  "region.antarctica": "Antarktis",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Forskyver tektoniske plater for å danne land...",
+  "html.loading_app": "Laster applikasjon...",
+  "html.error_title": "⚠️ Feil ved Lasting av Applikasjon",
+  "html.error_message": "Kunne ikke laste applikasjonen. Vennligst oppdater siden og prøv igjen."
 }

--- a/internal/translations/translations/nl.json
+++ b/internal/translations/translations/nl.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oceanië",
-  "region.antarctica": "Antarctica"
+  "region.antarctica": "Antarctica",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Tektonische platen verschuiven om landen te vormen...",
+  "html.loading_app": "Applicatie laden...",
+  "html.error_title": "⚠️ Fout bij Laden van Applicatie",
+  "html.error_message": "Kan de applicatie niet laden. Ververs de pagina en probeer het opnieuw."
 }

--- a/internal/translations/translations/pl.json
+++ b/internal/translations/translations/pl.json
@@ -12,7 +12,7 @@
   "game.flag.question": "Do którego kraju należy ta flaga?",
   "game.correct": "Poprawnie! To jest {{.Country}}!",
   "game.wrong": "Źle! To było {{.Country}}",
-  "game.score": "Skóre: {{.Score}}/10",
+  "game.score": "Wynik: {{.Score}}/10",
   "game.complete": "Gra Zakończona! Końcowy Wynik: {{.Score}}/10 ({{.Percent}}%)",
   "error.loading_countries": "Błąd ładowania danych krajów",
   "game.list.select_region": "Wybierz Region",
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Ameryka",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antarktyda"
+  "region.antarctica": "Antarktyda",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Przesuwamy płyty tektoniczne, aby uformować państwa...",
+  "html.loading_app": "Ładowanie aplikacji...",
+  "html.error_title": "⚠️ Błąd Ładowania Aplikacji",
+  "html.error_message": "Nie udało się załadować aplikacji. Odśwież stronę i spróbuj ponownie."
 }

--- a/internal/translations/translations/pt.json
+++ b/internal/translations/translations/pt.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Américas",
   "region.oceania": "Oceânia",
-  "region.antarctica": "Antártida"
+  "region.antarctica": "Antártida",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Deslocando placas tectónicas para formar países...",
+  "html.loading_app": "Carregando aplicação...",
+  "html.error_title": "⚠️ Erro ao Carregar a Aplicação",
+  "html.error_message": "Falha ao carregar a aplicação. Por favor, atualize a página e tente novamente."
 }

--- a/internal/translations/translations/ro.json
+++ b/internal/translations/translations/ro.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "America",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antarctica"
+  "region.antarctica": "Antarctica",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Deplasarea plăcilor tectonice pentru a forma țări...",
+  "html.loading_app": "Se încarcă aplicația...",
+  "html.error_title": "⚠️ Eroare la Încărcarea Aplicației",
+  "html.error_message": "Nu s-a putut încărca aplicația. Vă rugăm să actualizați pagina și să încercați din nou."
 }

--- a/internal/translations/translations/sk.json
+++ b/internal/translations/translations/sk.json
@@ -83,5 +83,11 @@
   "region.europe": "Európa",
   "region.americas": "Amerika",
   "region.oceania": "Oceánia",
-  "region.antarctica": "Antarktída"
+  "region.antarctica": "Antarktída",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Posúvame tektonické dosky a formujeme štáty...",
+  "html.loading_app": "Načítanie aplikácie...",
+  "html.error_title": "⚠️ Chyba pri Načítaní Aplikácie",
+  "html.error_message": "Nepodarilo sa načítať aplikáciu. Obnovte prosím stránku a skúste to znova."
 }

--- a/internal/translations/translations/sv.json
+++ b/internal/translations/translations/sv.json
@@ -83,5 +83,11 @@
   "region.europe": "Europa",
   "region.americas": "Amerika",
   "region.oceania": "Oceanien",
-  "region.antarctica": "Antarktis"
+  "region.antarctica": "Antarktis",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Förskjuter tektoniska plattor för att bilda länder...",
+  "html.loading_app": "Laddar applikation...",
+  "html.error_title": "⚠️ Fel vid Laddning av Applikation",
+  "html.error_message": "Kunde inte ladda applikationen. Uppdatera sidan och försök igen."
 }

--- a/internal/translations/translations/sw.json
+++ b/internal/translations/translations/sw.json
@@ -83,5 +83,11 @@
   "region.europe": "Ulaya",
   "region.americas": "Amerika",
   "region.oceania": "Oceania",
-  "region.antarctica": "Antaktika"
+  "region.antarctica": "Antaktika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Kusogeza mabao ya tektoniki ili kuunda nchi...",
+  "html.loading_app": "Inapakia programu...",
+  "html.error_title": "⚠️ Kosa la Kupakia Programu",
+  "html.error_message": "Imeshindwa kupakia programu. Tafadhali onyesha upya ukurasa na ujaribu tena."
 }

--- a/internal/translations/translations/tr.json
+++ b/internal/translations/translations/tr.json
@@ -83,5 +83,11 @@
   "region.europe": "Avrupa",
   "region.americas": "Amerika",
   "region.oceania": "Okyanusya",
-  "region.antarctica": "Antarktika"
+  "region.antarctica": "Antarktika",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Ülkeler oluşturmak için tektonik plakalar kaydırılıyor...",
+  "html.loading_app": "Uygulama yükleniyor...",
+  "html.error_title": "⚠️ Uygulama Yükleme Hatası",
+  "html.error_message": "Uygulama yüklenemedi. Lütfen sayfayı yenileyin ve tekrar deneyin."
 }

--- a/internal/translations/translations/vi.json
+++ b/internal/translations/translations/vi.json
@@ -83,5 +83,11 @@
   "region.europe": "Châu Âu",
   "region.americas": "Châu Mỹ",
   "region.oceania": "Châu Đại Dương",
-  "region.antarctica": "Nam Cực"
+  "region.antarctica": "Nam Cực",
+  "game.list.country_item": "%d. %s",
+  "game.list.country_unknown": "%d. ?",
+  "html.loading": "Dịch chuyển các mảng kiến tạo để tạo thành các quốc gia...",
+  "html.loading_app": "Đang tải ứng dụng...",
+  "html.error_title": "⚠️ Lỗi Tải Ứng Dụng",
+  "html.error_message": "Không thể tải ứng dụng. Vui lòng làm mới trang và thử lại."
 }


### PR DESCRIPTION
Translation review summary
Issues found and fixed
Missing HTML translation keys
Problem: All 22 languages were missing 4 HTML keys (html.loading, html.loading_app, html.error_title, html.error_message)
Fixed: Added all HTML keys to all language files using translations from index.html
Incorrect language word — "Skóre"
Problem: Spanish, French, Italian, and Polish were using "Skóre" (Czech/Slovak) instead of their own words
Fixed:
Spanish: "Skóre" → "Puntuación"
French: "Skóre" → "Score"
Italian: "Skóre" → "Punteggio"
Polish: "Skóre" → "Wynik"
Note: Czech (cs.json) and Slovak (sk.json) correctly use "Skóre"
Key consistency
All translation files now have all 91 keys matching the English version
Placeholder formats (%s, %d, {{.Var}}) are consistent across languages